### PR TITLE
Add repository URL placeholder and template cleanup instructions

### DIFF
--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -24,11 +24,12 @@ After running the script, use this slash command to have Claude verify and compl
 ## What this command will do (after initialize.sh):
 
 1. **Verify the initialization was complete** - check that all placeholders were properly replaced
-2. **Review the generated code** for any missed customizations
-3. **Help customize the actual MCP tools** - replace example tools with your specific functionality
-4. **Update data models** to match your use case
-5. **Add any additional configuration** needed for your specific server
-6. **Verify the project builds and tests pass** after customization
+2. **Confirm template files were cleaned up** - ensure initialize.sh and .claude/commands were removed
+3. **Review the generated code** for any missed customizations
+4. **Help customize the actual MCP tools** - replace example tools with your specific functionality
+5. **Update data models** to match your use case
+6. **Add any additional configuration** needed for your specific server
+7. **Verify the project builds and tests pass** after customization
 
 ## If you haven't run initialize.sh yet:
 
@@ -98,11 +99,21 @@ After gathering your requirements, I will:
    make lint
    ```
 
-7. **Rewrite CLAUDE.md** to be project-specific and remove template instructions
+7. **Clean up template-specific files:**
+   ```bash
+   # Remove the initialization script
+   rm initialize.sh
+   
+   # Remove template slash commands
+   rm -rf .claude/commands/
+   ```
+
+8. **Rewrite CLAUDE.md** to be project-specific and remove template instructions
 
 ## Ready to start?
 
 **If you've already run `./initialize.sh`:**
+- The script should have already cleaned up template files automatically
 - Just let me know and I'll verify the initialization was complete and help with any remaining customization
 
 **If you haven't run the script yet:**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This template provides a clean, simple starting point for building MCP servers. 
 
 1. **Clone this template**:
    ```bash
-   git clone <this-repo> PLACEHOLDER_PROJECT_NAME
+   git clone PLACEHOLDER_REPO_URL PLACEHOLDER_PROJECT_NAME
    cd PLACEHOLDER_PROJECT_NAME
    ```
 

--- a/initialize.sh
+++ b/initialize.sh
@@ -118,6 +118,17 @@ gather_requirements() {
     if [[ -n "$input_project_name" ]]; then
         project_name="$input_project_name"
     fi
+    
+    # Repository URL for clone instructions
+    echo
+    echo "What is the URL of this repository?"
+    echo "This will be used in README.md clone instructions (e.g., 'https://github.com/user/repo.git')"
+    read -p "Repository URL: " repo_url
+    
+    while [[ -z "$repo_url" ]]; do
+        print_error "Repository URL cannot be empty."
+        read -p "Repository URL: " repo_url
+    done
 }
 
 # Function to replace placeholders in files
@@ -149,6 +160,7 @@ replace_placeholders() {
                 sed -i '' "s/PLACEHOLDER_SERVER_NAME/$server_name/g" "$file"
                 sed -i '' "s/PLACEHOLDER_PACKAGE_NAME/$package_name/g" "$file"
                 sed -i '' "s/PLACEHOLDER_PROJECT_NAME/$project_name/g" "$file"
+                sed -i '' "s|PLACEHOLDER_REPO_URL|$repo_url|g" "$file"
                 sed -i '' "s/placeholder-mcp-server/$docker_name/g" "$file"
                 sed -i '' "s/placeholder_package_name/$package_name/g" "$file"
             else
@@ -157,6 +169,7 @@ replace_placeholders() {
                 sed -i "s/PLACEHOLDER_SERVER_NAME/$server_name/g" "$file"
                 sed -i "s/PLACEHOLDER_PACKAGE_NAME/$package_name/g" "$file"
                 sed -i "s/PLACEHOLDER_PROJECT_NAME/$project_name/g" "$file"
+                sed -i "s|PLACEHOLDER_REPO_URL|$repo_url|g" "$file"
                 sed -i "s/placeholder-mcp-server/$docker_name/g" "$file"
                 sed -i "s/placeholder_package_name/$package_name/g" "$file"
             fi
@@ -372,6 +385,7 @@ show_summary() {
     echo "  🏷️  Server name: $server_name"  
     echo "  🐳 Docker image: $docker_name"
     echo "  📁 Project name: $project_name"
+    echo "  🔗 Repository URL: $repo_url"
     echo
     echo "Next steps:"
     echo "  1. Review and customize the tools in src/$package_name/server.py"
@@ -403,6 +417,7 @@ main() {
     echo "  Server name: $server_name"
     echo "  Docker image: $docker_name"
     echo "  Project name: $project_name"
+    echo "  Repository URL: $repo_url"
     echo
     
     read -p "Proceed with initialization? (y/N): " confirm


### PR DESCRIPTION
## Summary

This PR completes the template initialization system by adding repository URL placeholder functionality and ensuring proper cleanup of template-specific files.

## Changes Made

### Repository URL Placeholder
- Replace `<this-repo>` with `PLACEHOLDER_REPO_URL` in README.md clone instructions  
- Add repository URL prompt to initialize.sh script with validation
- Update sed replacement logic to handle URLs (using pipe separator)
- Include repository URL in configuration summaries

### Template Cleanup Instructions
- Update slash command to include explicit cleanup steps for manual initialization
- Document removal of initialize.sh and .claude/commands/ directory
- Clarify that the bash script already handles cleanup automatically
- Add verification step to confirm template files were properly removed

## Problem Solved

Users previously had to manually replace `<this-repo>` in clone instructions and remember to clean up template files. This PR ensures:
- Generated projects have working clone instructions with actual repository URLs
- Template-specific files are systematically removed after initialization
- Users get clean, professional projects without template artifacts

## User Experience

When running `./initialize.sh`, users are now prompted for all necessary information including repository URL, and the script automatically cleans up template files. For manual initialization, clear cleanup instructions are provided.

## Testing

- All tests pass
- Script syntax validation passes  
- Template builds correctly after changes
- Cleanup functionality verified in initialize.sh script

This ensures the template initialization process is complete and generates clean, professional MCP server projects.