### PR TITLE
Add LLM-friendly configuration to initialize.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,23 @@ For spawned projects, choose one of these initialization methods:
 /project:new-project
 ```
 
-Both methods will:
+**Option 3: LLM/Automated Configuration (Recommended for LLMs)**
+LLMs can configure the template without interactive prompts by editing the export variables at the top of `initialize.sh`:
+```bash
+# Edit these variables in initialize.sh
+export SERVER_DESCRIPTION="Database management server"
+export PACKAGE_NAME="database_manager"
+export SERVER_NAME="database-manager"
+export DOCKER_IMAGE_NAME="database-mcp-server"
+export PROJECT_NAME="my-database-project"
+export REPOSITORY_URL="https://github.com/user/my-database-project.git"
+
+# Then run the script
+./initialize.sh
+```
+
+All methods will:
 - Detect if this is a spawned project automatically
-- Guide you through gathering project requirements
 - Replace all placeholders systematically
 - Rename packages and update imports
 - Verify the project builds correctly


### PR DESCRIPTION
## Summary

- Add export variables at the top of initialize.sh for automated configuration without interactive prompts
- Modify script logic to detect and use environment variables when all required values are set
- Maintain full backward compatibility with existing interactive mode

## Benefits

- LLMs can now configure the template by simply editing export variables at the top of the script
- Eliminates the need for stdin interaction when automating template initialization
- Provides clear validation and error messages for environment variable configuration
- Auto-proceeds when using environment configuration, skipping manual confirmation

## Changes

- **initialize.sh**: Added configuration variables section with export statements and usage examples
- **initialize.sh**: Enhanced gather_requirements() function to check environment variables first
- **initialize.sh**: Skip confirmation prompt when using environment configuration
- **CLAUDE.md**: Added Option 3 documentation for LLM/automated configuration usage

## Testing

- Script syntax validated with bash -n
- Maintains all existing validation logic and error handling
- Backward compatible with existing interactive workflow