### PR TITLE
Emphasize running initialize.sh after gathering requirements

### DIFF
--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -2,24 +2,34 @@
 
 This command helps you quickly initialize a new MCP server project from this template by replacing all placeholders with your project-specific values.
 
-## Recommended Approach: Use the Bash Script First
+## CRITICAL WORKFLOW FOR CLAUDE CODE:
 
-**STEP 1: Run the automated initialization script**
+**When the user asks to initialize a new project, you MUST:**
 
-```bash
-./initialize.sh
-```
+1. **FIRST: Gather the user's requirements**
+   - What will the MCP server do?
+   - What should the package be named?
+   - What's the server name for MCP clients?
+   - What's the Docker image name?
+   - What's the repository URL?
 
-This script will handle most of the initialization automatically:
-- Interactive guided setup with input validation
-- Replace all placeholders systematically
-- Rename packages and update imports
-- Run tests to verify everything works
-- Generate project-specific documentation
+2. **THEN: Edit the initialize.sh script with the gathered values**
+   ```bash
+   # Edit the export variables at the top of initialize.sh:
+   export SERVER_DESCRIPTION="[user's description]"
+   export PACKAGE_NAME="[user's package name]"
+   export SERVER_NAME="[user's server name]"
+   export DOCKER_IMAGE_NAME="[user's docker image name]"
+   export PROJECT_NAME="[project name or leave empty for current dir]"
+   export REPOSITORY_URL="[user's repo URL]"
+   ```
 
-**STEP 2: Manual verification and Claude assistance**
+3. **FINALLY: Run the script**
+   ```bash
+   ./initialize.sh
+   ```
 
-After running the script, use this slash command to have Claude verify and complete any remaining customization:
+The script will handle everything automatically - no manual steps needed!
 
 ## What this command will do (after initialize.sh):
 
@@ -112,12 +122,20 @@ After gathering your requirements, I will:
 
 ## Ready to start?
 
-**If you've already run `./initialize.sh`:**
-- The script should have already cleaned up template files automatically
-- Just let me know and I'll verify the initialization was complete and help with any remaining customization
+**REMEMBER: The correct workflow is:**
+1. Gather requirements from the user
+2. Edit the export variables in initialize.sh
+3. Run ./initialize.sh
 
-**If you haven't run the script yet:**
-- Please run `./initialize.sh` first for the best experience, then come back to this command
-- OR provide your answers to the questions above, and I'll do the manual transformation
+**The script will automatically:**
+- Replace ALL placeholders
+- Rename the package directory  
+- Update all imports
+- Run tests to verify setup
+- Rewrite CLAUDE.md
+- Clean up template files
+- Show a summary of the configuration
 
-Either way, I'll help ensure your MCP server template becomes a fully customized project!
+**DO NOT attempt manual placeholder replacement** - the script handles everything!
+
+If the user has already run initialize.sh, verify the initialization was complete and help with any remaining customization of the actual MCP tools and functionality.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,11 @@ This is a **template repository** for creating MCP (Model Context Protocol) serv
 - If the directory name is `python-mcp-server-template`, this is the template repository
 - If the directory name is anything else, this is likely a spawned project that needs initialization
 
+**IMPORTANT FOR CLAUDE CODE: When initializing a spawned project:**
+1. First gather the user's requirements (what the server will do, package name, etc.)
+2. **THEN IMMEDIATELY RUN `./initialize.sh`** with the gathered information
+3. The script will handle all placeholder replacements and setup automatically
+
 **AUTOMATED INITIALIZATION: Multiple Options**
 
 For spawned projects, choose one of these initialization methods:
@@ -71,7 +76,22 @@ All methods will:
    - Ask: "What will your MCP server do? (e.g., 'manage databases', 'process documents', 'integrate with APIs')"
    - Ask: "What would you like to name your package? (e.g., 'database_manager', 'document_processor')"
 
-2. **Perform template customization by replacing ALL placeholders:**
+2. **CRITICAL: After gathering requirements, RUN the initialization script:**
+   ```bash
+   # First, edit the variables at the top of initialize.sh with the gathered information
+   # Then run:
+   ./initialize.sh
+   ```
+   
+   **The script will automatically:**
+   - Replace all placeholders with the provided values
+   - Rename the package directory
+   - Update all imports
+   - Run tests to verify the setup
+   - Rewrite CLAUDE.md to be project-specific
+   - Clean up template files (including itself)
+
+3. **If initialize.sh is not available or fails, perform manual customization:**
    
    **CRITICAL: Find all placeholders first:**
    ```bash
@@ -91,12 +111,7 @@ All methods will:
    - Update `pyproject.toml` with new name, description, and metadata
    - Replace example tools/resources/prompts with placeholder stubs for their use case
    - Update the main.py description
-
-3. **After customization, REWRITE THIS CLAUDE.md file:**
-   - Replace template instructions with project-specific guidance
-   - Include their specific MCP server purpose and functionality
-   - Keep the development workflow but make it project-specific
-   - Remove template initialization instructions
+   - After customization, REWRITE THIS CLAUDE.md file to be project-specific
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md and slash command to ensure Claude Code runs initialize.sh after gathering requirements
- Made the workflow crystal clear: gather → edit variables → run script

## Context
The initialize.sh script from recent commits works great, but Claude Code was sometimes forgetting to run it after gathering requirements from users. This PR updates the documentation to make it unmistakably clear that Claude should run the script rather than attempting manual placeholder replacement.

## Changes
1. **CLAUDE.md updates:**
   - Added prominent section emphasizing the workflow for Claude Code
   - Restructured manual initialization section to prioritize running initialize.sh
   - Made it clear that manual replacement is only a fallback if the script fails

2. **Slash command updates:**
   - Added "CRITICAL WORKFLOW FOR CLAUDE CODE" section at the top
   - Clearly outlined the 3-step process: gather → edit → run
   - Emphasized that the script handles everything automatically
   - Added reminder at the end to not attempt manual replacement

## Test plan
- [x] Verified tests still pass with `make test`
- [x] Verified linting passes with `make lint`
- [ ] Test with Claude Code to ensure it follows the new workflow